### PR TITLE
Set owner to `null` when renouncing the ownership

### DIFF
--- a/src/main/java/com/altoros/aion/Ownable.java
+++ b/src/main/java/com/altoros/aion/Ownable.java
@@ -54,7 +54,7 @@ public class Ownable {
     @Callable
     public static void renounceOwnership() {
         onlyOwner();
-        setOwner(NO_ADDRESS);
+        owner = null;
     }
 
     /**


### PR DESCRIPTION
Since null is supported in Java and AVM, why not assign owner to null if it doesn't have an owner?